### PR TITLE
res_partner_ru is not installable in 8.0, because there is no

### DIFF
--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,0 +1,1 @@
+misc-addons https://github.com/it-projects-llc/misc-addons

--- a/res_partner_ru/__openerp__.py
+++ b/res_partner_ru/__openerp__.py
@@ -14,5 +14,5 @@
     "data": [
         'templates.xml'
     ],
-    "installable": True
+    "installable": False,
 }

--- a/sale_report_kz/__openerp__.py
+++ b/sale_report_kz/__openerp__.py
@@ -20,5 +20,5 @@
     "data": [
         'report.xml',
     ],
-    "installable": True
+    "installable": False
 }


### PR DESCRIPTION
l10n_ru (l10n_ru2) module